### PR TITLE
fixes #2 error message fix

### DIFF
--- a/bootstrap/grammar.go
+++ b/bootstrap/grammar.go
@@ -177,14 +177,16 @@ func (p Parsers) Unparse(v interface{}, w io.Writer) (n int, err error) {
 
 // Parse parses some source per a given rule.
 func (p Parsers) Parse(rule Rule, input *parse.Scanner) (interface{}, error) {
-	var v interface{}
-	if err := p.parsers[rule].Parse(input, &v); err != nil {
-		return nil, err
+	for {
+		var v interface{}
+		if err := p.parsers[rule].Parse(input, &v); err != nil {
+			return nil, err
+		}
+
+		if input.String() == "" {
+			return v, nil
+		}
 	}
-	if input.String() == "" {
-		return v, nil
-	}
-	return nil, fmt.Errorf("unconsumed input: %v", input.Context())
 }
 
 // Term represents the terms of a grammar specification.


### PR DESCRIPTION
Instead of stopping after partial match, it will try to parse the partially consumed input to get the right error message out