### PR TITLE
Includes file, line and column number in Scanner

### DIFF
--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -15,29 +15,30 @@ type Scanner struct {
 type source interface {
 	length() int                // the length of the entire source string
 	slice(i, length int) string // the string of the given slice
-	filename() *string          // the name of the file from which the source is derived (if any)
+	filename() string           // the name of the file from which the source is derived (or empty if none)
 }
 
 type stringSource struct {
 	origin *string // the entire source string
-	f      *string // the source filename
+	f      string  // the source filename
 }
 
 func NewScanner(str string) *Scanner {
-	return &Scanner{stringSource{&str, nil}, 0, len(str)}
+	return &Scanner{stringSource{origin: &str}, 0, len(str)}
 }
 
 func NewScannerWithFilename(str, filename string) *Scanner {
-	return &Scanner{stringSource{&str, &filename}, 0, len(str)}
+	return &Scanner{stringSource{&str, filename}, 0, len(str)}
 }
 
 func NewScannerAt(str string, offset, size int) *Scanner {
-	return &Scanner{stringSource{&str, nil}, offset, size}
+	return &Scanner{stringSource{origin: &str}, offset, size}
 }
 
 // - Scanner
 
-func (s Scanner) Filename() *string {
+// The name of the file from which the source is derived (or empty if none).
+func (s Scanner) Filename() string {
 	return s.src.filename()
 }
 
@@ -140,7 +141,7 @@ func (s stringSource) slice(i, length int) string {
 	return (*s.origin)[i : i+length]
 }
 
-func (s stringSource) filename() *string {
+func (s stringSource) filename() string {
 	return s.f
 }
 

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -7,41 +7,32 @@ import (
 )
 
 type Scanner struct {
-	src source // the source the scanner is drawing from
+	src         source // the source the scanner is drawing from
+	sliceStart  int    // the start of the slice visible to the scanner
+	sliceLength int    // the length of the slice visible to the scanner
 }
 
 type source interface {
-	filename() *string            // the name of the file from which the source was retrieved (if any)
-	slice() string                // the sliced string
-	sliceInfo() sliceInfo         // the sliced range information (relative to the entire source)
-	sliceIn(i, length int) source // a new source sliced within the current slice
-	prefix() string               // the prefix (before the slice - for debugging)
-	suffix() string               // the suffix (after the slice - for debugging)
-}
-
-type sliceInfo struct {
-	start  int // the (inclusive) start of the slice range within the source
-	length int // the length of slice range
-	line   int // the 1-indexed line number of the start of the slice within the source
-	column int // the 1-indexed column number of the start of the slice within the source line
+	length() int                // the length of the entire source string
+	slice(i, length int) string // the string of the given slice
+	filename() *string          // the name of the file from which the source is derived (if any)
 }
 
 type stringSource struct {
-	f      *string   // the location of the origin file in the file system
-	origin *string   // the entire origin string
-	info   sliceInfo // the slice range information (relative to the origin string)
+	origin *string // the entire source string
+	f      *string // the source filename
 }
 
 func NewScanner(str string) *Scanner {
-	return &Scanner{stringSource{origin: &str, info: newSliceInfo(str, 0, len(str))}}
+	return &Scanner{stringSource{&str, nil}, 0, len(str)}
 }
 
 func NewScannerWithFilename(str, filename string) *Scanner {
-	return &Scanner{stringSource{f: &filename, origin: &str, info: newSliceInfo(str, 0, len(str))}}
+	return &Scanner{stringSource{&str, &filename}, 0, len(str)}
 }
 
 func NewScannerAt(str string, offset, size int) *Scanner {
-	return &Scanner{stringSource{origin: &str, info: newSliceInfo(str, offset, size)}}
+	return &Scanner{stringSource{&str, nil}, offset, size}
 }
 
 // - Scanner
@@ -54,56 +45,59 @@ func (s Scanner) String() string {
 	if s.src == nil {
 		return ""
 	}
-	return s.src.slice()
+	return s.slice()
 }
 
 func (s Scanner) Format(state fmt.State, c rune) {
 	if c == 'q' {
-		_, _ = fmt.Fprintf(state, "%q", s.src.slice())
+		_, _ = fmt.Fprintf(state, "%q", s.slice())
 	} else {
-		_, _ = state.Write([]byte(s.src.slice()))
+		_, _ = state.Write([]byte(s.slice()))
 	}
 }
 
 func (s Scanner) Context() string {
+	end := s.sliceStart + s.sliceLength
 	return fmt.Sprintf("%s\033[1;31m%s\033[0m%s",
-		s.src.prefix(),
-		s.src.slice(),
-		s.src.suffix(),
+		s.src.slice(0, s.sliceStart),
+		s.slice(),
+		s.src.slice(end, s.src.length()-end),
 	)
 }
 
 // The position of the start of the scanner within the original source.
 func (s Scanner) Offset() int {
-	return s.src.sliceInfo().start
+	return s.sliceStart
 }
 
-// The 1-indexed line number of the start of the scanner within the original source.
-func (s Scanner) Line() int {
-	return s.src.sliceInfo().line
+// The 1-indexed line and column number of the start of the scanner within the original source.
+func (s Scanner) Position() (int, int) {
+	return lineColumn(s.src.slice(0, s.sliceStart), s.sliceStart)
 }
 
-// The 1-indexed column number of the start of the scanner within the original source.
-func (s Scanner) Column() int {
-	return s.src.sliceInfo().column
+// The slice that is visible to the scanner
+func (s Scanner) slice() string {
+	return s.src.slice(s.sliceStart, s.sliceLength)
 }
 
 func (s Scanner) Slice(a, b int) *Scanner {
-	return &Scanner{src: s.src.sliceIn(a, b-a)}
+	return &Scanner{s.src, s.sliceStart + a, b - a}
 }
 
 func (s Scanner) Skip(i int) *Scanner {
-	return &Scanner{src: s.src.sliceIn(i, s.src.sliceInfo().length-i)}
+	return &Scanner{s.src, s.sliceStart + i, s.sliceLength - i}
 }
 
 func (s *Scanner) Eat(i int, eaten *Scanner) *Scanner {
-	eaten.src = s.src.sliceIn(0, i)
+	eaten.src = s.src
+	eaten.sliceStart = s.sliceStart
+	eaten.sliceLength = i
 	*s = *s.Skip(i)
 	return s
 }
 
 func (s *Scanner) EatString(str string, eaten *Scanner) bool {
-	if strings.HasPrefix(s.src.slice(), str) {
+	if strings.HasPrefix(s.slice(), str) {
 		s.Eat(len(str), eaten)
 		return true
 	}
@@ -114,7 +108,7 @@ func (s *Scanner) EatString(str string, eaten *Scanner) bool {
 // the whole match and captures (if != nil) with any captured groups. Returns
 // n as the number of captures set and ok iff a match was found.
 func (s *Scanner) EatRegexp(re *regexp.Regexp, match *Scanner, captures []Scanner) (n int, ok bool) {
-	if loc := re.FindStringSubmatchIndex(s.src.slice()); loc != nil {
+	if loc := re.FindStringSubmatchIndex(s.slice()); loc != nil {
 		if loc[0] != 0 {
 			panic(`re not \A-anchored`)
 		}
@@ -138,45 +132,16 @@ func (s *Scanner) EatRegexp(re *regexp.Regexp, match *Scanner, captures []Scanne
 
 // - stringSource
 
+func (s stringSource) length() int {
+	return len(*s.origin)
+}
+
+func (s stringSource) slice(i, length int) string {
+	return (*s.origin)[i : i+length]
+}
+
 func (s stringSource) filename() *string {
 	return s.f
-}
-
-func (s stringSource) slice() string {
-	return (*s.origin)[s.info.start:s.info.start + s.info.length]
-}
-
-func (s stringSource) sliceInfo() sliceInfo {
-	return s.info
-}
-
-func (s stringSource) sliceIn(i, length int) source {
-	skippedLine, skippedCol := lineColumn(s.slice()[:i], i)
-	var line, col int
-	if skippedLine == 1 {
-		line = s.info.line
-		col = s.info.column + skippedCol - 1
-	} else {
-		line = s.info.line + skippedLine - 1
-		col = skippedCol
-	}
-	info := sliceInfo{s.info.start + i, length, line, col}
-	return stringSource{f: s.f, origin: s.origin, info: info}
-
-}
-
-func (s stringSource) prefix() string {
-	return (*s.origin)[0:s.info.start]
-}
-
-func (s stringSource) suffix() string {
-	return (*s.origin)[s.info.start + s.info.length:]
-}
-
-// The slice info for the given string and range.
-func newSliceInfo(str string, start, length int) sliceInfo {
-	line, col := lineColumn(str, start)
-	return sliceInfo{start: start, length: length, line: line, column: col}
 }
 
 // The 1-indexed line and column number of the given position within the given string.

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -7,75 +7,104 @@ import (
 )
 
 type Scanner struct {
-	src    string
-	slice  string
-	offset int
+	src source // the source the scanner is drawing from
 }
 
-func NewScanner(src string) *Scanner {
-	return &Scanner{src: src, slice: src, offset: 0}
+type source interface {
+	filename() *string            // the name of the file from which the source was retrieved (if any)
+	slice() string                // the sliced string
+	sliceInfo() sliceInfo         // the sliced range information (relative to the entire source)
+	sliceIn(i, length int) source // a new source sliced within the current slice
+	prefix() string               // the prefix (before the slice - for debugging)
+	suffix() string               // the suffix (after the slice - for debugging)
 }
 
-func NewScannerAt(src string, offset, size int) *Scanner {
-	return &Scanner{src: src, slice: src[offset : offset+size], offset: offset}
+type sliceInfo struct {
+	start  int // the (inclusive) start of the slice range within the source
+	length int // the length of slice range
+	line   int // the 1-indexed line number of the start of the slice within the source
+	column int // the 1-indexed column number of the start of the slice within the source line
 }
 
-func NewBareScanner(offset int, slice string) *Scanner {
-	return &Scanner{slice: slice, offset: offset}
+type stringSource struct {
+	f      *string   // the location of the origin file in the file system
+	origin *string   // the entire origin string
+	info   sliceInfo // the slice range information (relative to the origin string)
 }
 
-func (r Scanner) String() string {
-	return r.slice
+func NewScanner(str string) *Scanner {
+	return &Scanner{stringSource{origin: &str, info: newSliceInfo(str, 0, len(str))}}
 }
 
-func (r Scanner) StripSource() Scanner {
-	r.src = ""
-	return r
+func NewScannerWithFilename(str, filename string) *Scanner {
+	return &Scanner{stringSource{f: &filename, origin: &str, info: newSliceInfo(str, 0, len(str))}}
 }
 
-func (r Scanner) Format(state fmt.State, c rune) {
+func NewScannerAt(str string, offset, size int) *Scanner {
+	return &Scanner{stringSource{origin: &str, info: newSliceInfo(str, offset, size)}}
+}
+
+// - Scanner
+
+func (s Scanner) Filename() *string {
+	return s.src.filename()
+}
+
+func (s Scanner) String() string {
+	if s.src == nil {
+		return ""
+	}
+	return s.src.slice()
+}
+
+func (s Scanner) Format(state fmt.State, c rune) {
 	if c == 'q' {
-		fmt.Fprintf(state, "%q", r.String())
+		_, _ = fmt.Fprintf(state, "%q", s.src.slice())
 	} else {
-		state.Write([]byte(r.String()))
+		_, _ = state.Write([]byte(s.src.slice()))
 	}
 }
 
-func (r Scanner) Context() string {
+func (s Scanner) Context() string {
 	return fmt.Sprintf("%s\033[1;31m%s\033[0m%s",
-		r.src[:r.offset],
-		r.slice,
-		r.src[r.offset+len(r.slice):],
+		s.src.prefix(),
+		s.src.slice(),
+		s.src.suffix(),
 	)
 }
 
-func (r Scanner) Offset() int {
-	return r.offset
+// The position of the start of the scanner within the original source.
+func (s Scanner) Offset() int {
+	return s.src.sliceInfo().start
 }
 
-func (r Scanner) Slice(a, b int) *Scanner {
-	return &Scanner{
-		src:    r.src,
-		slice:  r.slice[a:b],
-		offset: r.offset + a,
-	}
+// The 1-indexed line number of the start of the scanner within the original source.
+func (s Scanner) Line() int {
+	return s.src.sliceInfo().line
 }
 
-func (r Scanner) Skip(i int) *Scanner {
-	return r.Slice(i, len(r.slice))
+// The 1-indexed column number of the start of the scanner within the original source.
+func (s Scanner) Column() int {
+	return s.src.sliceInfo().column
 }
 
-func (r *Scanner) Eat(i int, eaten *Scanner) *Scanner {
-	eaten.src = r.src
-	eaten.slice = r.slice[:i]
-	eaten.offset = r.offset
-	*r = *r.Skip(i)
-	return r
+func (s Scanner) Slice(a, b int) *Scanner {
+	return &Scanner{src: s.src.sliceIn(a, b-a)}
 }
 
-func (r *Scanner) EatString(s string, eaten *Scanner) bool {
-	if strings.HasPrefix(r.String(), s) {
-		r.Eat(len(s), eaten)
+func (s Scanner) Skip(i int) *Scanner {
+	return &Scanner{src: s.src.sliceIn(i, s.src.sliceInfo().length-i)}
+}
+
+func (s *Scanner) Eat(i int, eaten *Scanner) *Scanner {
+	eaten.src = s.src.sliceIn(0, i)
+	*s = *s.Skip(i)
+	return s
+}
+
+func (s *Scanner) EatString(str string, eaten *Scanner) bool {
+	if strings.HasPrefix(s.src.slice(), str) {
+		s.Eat(len(str), eaten)
 		return true
 	}
 	return false
@@ -84,13 +113,13 @@ func (r *Scanner) EatString(s string, eaten *Scanner) bool {
 // EatRegexp eats the text matching a regexp, populating match (if != nil) with
 // the whole match and captures (if != nil) with any captured groups. Returns
 // n as the number of captures set and ok iff a match was found.
-func (r *Scanner) EatRegexp(re *regexp.Regexp, match *Scanner, captures []Scanner) (n int, ok bool) {
-	if loc := re.FindStringSubmatchIndex(r.String()); loc != nil {
+func (s *Scanner) EatRegexp(re *regexp.Regexp, match *Scanner, captures []Scanner) (n int, ok bool) {
+	if loc := re.FindStringSubmatchIndex(s.src.slice()); loc != nil {
 		if loc[0] != 0 {
 			panic(`re not \A-anchored`)
 		}
 		if match != nil {
-			*match = *r.Slice(loc[0], loc[1])
+			*match = *s.Slice(loc[0], loc[1])
 		}
 		skip := loc[1]
 		loc = loc[2:]
@@ -99,10 +128,61 @@ func (r *Scanner) EatRegexp(re *regexp.Regexp, match *Scanner, captures []Scanne
 			captures = captures[:n]
 		}
 		for i := range captures {
-			captures[i] = *r.Slice(loc[2*i], loc[2*i+1])
+			captures[i] = *s.Slice(loc[2*i], loc[2*i+1])
 		}
-		*r = *r.Skip(skip)
+		*s = *s.Skip(skip)
 		return n, true
 	}
 	return 0, false
+}
+
+// - stringSource
+
+func (s stringSource) filename() *string {
+	return s.f
+}
+
+func (s stringSource) slice() string {
+	return (*s.origin)[s.info.start:s.info.start + s.info.length]
+}
+
+func (s stringSource) sliceInfo() sliceInfo {
+	return s.info
+}
+
+func (s stringSource) sliceIn(i, length int) source {
+	skippedLine, skippedCol := lineColumn(s.slice()[:i], i)
+	var line, col int
+	if skippedLine == 1 {
+		line = s.info.line
+		col = s.info.column + skippedCol - 1
+	} else {
+		line = s.info.line + skippedLine - 1
+		col = skippedCol
+	}
+	info := sliceInfo{s.info.start + i, length, line, col}
+	return stringSource{f: s.f, origin: s.origin, info: info}
+
+}
+
+func (s stringSource) prefix() string {
+	return (*s.origin)[0:s.info.start]
+}
+
+func (s stringSource) suffix() string {
+	return (*s.origin)[s.info.start + s.info.length:]
+}
+
+// The slice info for the given string and range.
+func newSliceInfo(str string, start, length int) sliceInfo {
+	line, col := lineColumn(str, start)
+	return sliceInfo{start: start, length: length, line: line, column: col}
+}
+
+// The 1-indexed line and column number of the given position within the given string.
+func lineColumn(str string, pos int) (line, col int) {
+	prefix := str[:pos]
+	line = strings.Count(prefix, "\n") + 1
+	col = pos - strings.LastIndex(prefix, "\n")
+	return
 }

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -1,0 +1,36 @@
+package parser
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestScannerLineColumn(t *testing.T) {
+	scanner := NewScanner("one\ntwo\nthree\nfour")
+
+	// test the scanner starts at position 1,1
+	assertLineColumn(t, scanner, 1, 1)
+
+	// eat within the same line:
+	// test the eaten scanner is left at the existing position
+	// test the scanner is advanced within the line
+	eaten := Scanner{}
+	scanner.Eat(1, &eaten)
+	assertLineColumn(t, &eaten, 1, 1)
+	assertLineColumn(t, scanner, 1, 2)
+
+	// eat a line
+	scanner.Eat(3, &eaten)
+	assertLineColumn(t, &eaten, 1, 2)
+	assertLineColumn(t, scanner, 2, 1)
+
+	// eat multiple lines and into a column
+	scanner.Eat(12, &eaten)
+	assertLineColumn(t, &eaten, 2, 1)
+	assertLineColumn(t, scanner, 4, 3)
+}
+
+func assertLineColumn(t *testing.T, scanner *Scanner, line, column int) {
+	assert.Equal(t, line, scanner.Line())
+	assert.Equal(t, column, scanner.Column())
+}

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -31,6 +31,7 @@ func TestScannerLineColumn(t *testing.T) {
 }
 
 func assertLineColumn(t *testing.T, scanner *Scanner, line, column int) {
-	assert.Equal(t, line, scanner.Line())
-	assert.Equal(t, column, scanner.Column())
+	l, c := scanner.Position()
+	assert.Equal(t, line, l)
+	assert.Equal(t, column, c)
 }

--- a/wbnf/compile.go
+++ b/wbnf/compile.go
@@ -308,7 +308,7 @@ type compiler struct {
 }
 
 func (c *compiler) makeGrammar(filename, text string) (GrammarNode, error) {
-	node, err := ParseString(text)
+	node, err := Parse(parser.NewScannerWithFilename(text, filename))
 	if err != nil {
 		return GrammarNode{}, err
 	}


### PR DESCRIPTION
This change also modifies the Scanner internally to maintain the slice
range for derived scanner instances, not the sliced string subset.