### PR TITLE
Restores arrai grammar parsing

### DIFF
--- a/wbnf/cutpoints.go
+++ b/wbnf/cutpoints.go
@@ -161,7 +161,7 @@ func fixTerm(term parser.Term, callback func(t parser.Term) parser.Term) parser.
 	case parser.CutPoint:
 		t.Term = fixTerm(t.Term, callback)
 		return callback(t)
-	case parser.S, parser.REF, parser.RE, parser.Rule:
+	case parser.S, parser.REF, parser.RE, parser.Rule, parser.ExtRef:
 		return callback(term)
 	default:
 		panic("unexpected term")


### PR DESCRIPTION
Fixes invalid parse resulting from missing term in grammar rebuild.