### PR TITLE
codegen: Don't strip space/nl from nodes

### DIFF
--- a/cmd/codegen/grammar.go
+++ b/cmd/codegen/grammar.go
@@ -45,7 +45,7 @@ func (g *goNode) Add(n goNode) {
 }
 
 func safeString(src string) string {
-	r := strings.NewReplacer("`", "`+\"`\"+`", " ", "", "\n", "")
+	r := strings.NewReplacer("`", "`+\"`\"+`")
 	return r.Replace(src)
 }
 

--- a/cmd/codegen/grammar_test.go
+++ b/cmd/codegen/grammar_test.go
@@ -1,0 +1,30 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/arr-ai/wbnf/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestWalkTermTerminal tests the the output of terminal nodes in AST (those
+// with no children (noScope).
+func TestWalkTermTerminal(t *testing.T) {
+	// Note: These tests are far from comprehensive. They include enough
+	// to test fixes for #59 (Generated Go code removes spaces from regexes)
+	tests := map[string]struct {
+		input  parser.Term
+		output string
+	}{
+		"S simple":  {parser.S("hello"), "parser.S(`hello`)"},
+		"S newline": {parser.S("\n"), "parser.S(`\n`)"},
+		"RE simple": {parser.RE("[A-Z]+"), "parser.RE(`[A-Z]+`)"},
+		"RE space":  {parser.RE("[ ]+"), "parser.RE(`[ ]+`)"},
+	}
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tt.output, walkTerm(tt.input).name)
+		})
+	}
+}


### PR DESCRIPTION
Do not strip spaces or newlines from nodes in the AST when generating Go
code. If there is a space or newline in the AST, then it should be there
in the generated code. The codegen should just make sure that the
emitted code will compile and do whatever escaping is necessary to
ensure that.

Fixes: #59