### PR TITLE
Add filename, line number and column number to scanner context

### DIFF
--- a/ast/helpers.go
+++ b/ast/helpers.go
@@ -1,6 +1,8 @@
 package ast
 
-import "github.com/arr-ai/wbnf/parser"
+import (
+	"github.com/arr-ai/wbnf/parser"
+)
 
 // Which returns the first child of the branch from the list of names supplied
 func Which(b Branch, names ...string) (string, Children) {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -141,7 +141,7 @@ func test(c *cli.Context) error {
 	if !g.HasRule(parser.Rule(startingRule)) {
 		return fmt.Errorf("starting rule '%s' not in test grammar", startingRule)
 	}
-	tree, err := g.Parse(parser.Rule(startingRule), parser.NewScanner(input))
+	tree, err := g.Parse(parser.Rule(startingRule), parser.NewScannerWithFilename(input, source))
 	if err != nil {
 		if uci, ok := err.(parser.UnconsumedInputError); ok {
 			logrus.Warningln("Partial result:")

--- a/parser/error.go
+++ b/parser/error.go
@@ -69,7 +69,7 @@ func UnconsumedInput(residue Scanner, result TreeElement) UnconsumedInputError {
 }
 
 func (e UnconsumedInputError) Error() string {
-	return fmt.Sprintf("unconsumed input: %v", e.residue)
+	return fmt.Sprintf("unconsumed input\n %v", e.residue.Context())
 }
 
 func (e UnconsumedInputError) Result() TreeElement { return e.tree }

--- a/parser/error.go
+++ b/parser/error.go
@@ -69,7 +69,7 @@ func UnconsumedInput(residue Scanner, result TreeElement) UnconsumedInputError {
 }
 
 func (e UnconsumedInputError) Error() string {
-	return fmt.Sprintf("unconsumed input\n %v", e.residue.Context())
+	return fmt.Sprintf("unconsumed input\n %v", e.residue.Context(DefaultLimit))
 }
 
 func (e UnconsumedInputError) Result() TreeElement { return e.tree }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -186,7 +186,7 @@ func getErrorStrings(input *Scanner) string {
 		text = text[:40] + "  ..."
 	}
 
-	return NewScanner(text).Context()
+	return NewScanner(text).Context(DefaultLimit)
 }
 
 func eatRegexp(input *Scanner, re *regexp.Regexp, output *TreeElement) bool {
@@ -233,7 +233,7 @@ func (p *sParser) Parse(scope Scope, input *Scanner, output *TreeElement) error 
 	}
 	if ok := eatRegexp(input, p.re, output); !ok {
 		return newParseError(p.rule, "", scope.GetCutPoint(),
-			fmt.Errorf("expect: %s", NewScanner(p.t.String()).Context()),
+			fmt.Errorf("expect: %s", NewScanner(p.t.String()).Context(DefaultLimit)),
 			fmt.Errorf("actual: %s", getErrorStrings(input)), scope.GetCallStack())
 	}
 	return nil
@@ -261,7 +261,7 @@ func (p *reParser) Parse(scope Scope, input *Scanner, output *TreeElement) error
 	}
 	if ok := eatRegexp(input, p.re, output); !ok {
 		return newParseError(p.rule, "", scope.GetCutPoint(),
-			fmt.Errorf("expect: %s", NewScanner(p.re.String()).Context()),
+			fmt.Errorf("expect: %s", NewScanner(p.re.String()).Context(DefaultLimit)),
 			fmt.Errorf("actual: %s", getErrorStrings(input)), scope.GetCallStack())
 	}
 	return nil

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -1,8 +1,9 @@
 package parser
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestScannerLineColumn(t *testing.T) {

--- a/wbnf/cutpoints.go
+++ b/wbnf/cutpoints.go
@@ -2,6 +2,7 @@ package wbnf
 
 import (
 	"fmt"
+
 	"github.com/arr-ai/frozen"
 	"github.com/arr-ai/wbnf/parser"
 )

--- a/wbnf/grammar_test.go
+++ b/wbnf/grammar_test.go
@@ -49,7 +49,7 @@ func assertParseToNode(t *testing.T, expected parser.Node, rule parser.Rule, inp
 	if assert.NoError(t, err) {
 		return parser.AssertEqualNodes(t, expected, v.(parser.Node))
 	} else {
-		t.Logf("input: %s", input.Context())
+		t.Logf("input: %s", input.Context(parser.NoLimit))
 	}
 	return false
 }
@@ -175,8 +175,8 @@ func TestExprGrammarGrammar(t *testing.T) {
 	parsers := Core()
 	r := parser.NewScanner(exprGrammarSrc)
 	v, err := parsers.Parse("grammar", r)
-	require.NoError(t, err, "r=%v\nv=%v", r.Context(), v)
-	require.Equal(t, len(exprGrammarSrc), r.Offset(), "r=%v\nv=%v", r.Context(), v)
+	require.NoError(t, err, "r=%v\nv=%v", r.Context(parser.NoLimit), v)
+	require.Equal(t, len(exprGrammarSrc), r.Offset(), "r=%v\nv=%v", r.Context(parser.NoLimit), v)
 	assertUnparse(t,
 		`// Simple expression grammar`+
 			`expr->@:[-+]`+


### PR DESCRIPTION
Fixed #3.

Changes:
- add filename, line number and column number to scanner context
- limit the output error context 
- add filename to wbnf test command error

![image](https://user-images.githubusercontent.com/13619421/78755830-2c770980-79bd-11ea-88bc-ff95875d2f00.png)
