### PR TITLE
implement Scanner for Many and Branch

### DIFF
--- a/ast/node_string.go
+++ b/ast/node_string.go
@@ -120,12 +120,15 @@ func (c Many) Scanner() parser.Scanner {
 		childrenScanners = append(childrenScanners, n.Scanner())
 	}
 
-	manyScanner, err := parser.MergeScanners(childrenScanners...)
-	if err != nil {
-		panic(err)
+	if len(childrenScanners) > 0 {
+		manyScanner, err := parser.MergeScanners(childrenScanners...)
+		if err != nil {
+			panic(err)
+		}
+		return manyScanner
 	}
 
-	return manyScanner
+	return parser.Scanner{}
 }
 
 func (c Extra) Scanner() parser.Scanner {
@@ -146,17 +149,24 @@ func (n Branch) Scanner() parser.Scanner {
 		if !strings.HasPrefix(childrenName, "@") {
 			switch c := ch.(type) {
 			case One:
-				scanners = append(scanners, c.Node.Scanner())
+				if s := c.Node.Scanner(); !s.IsNil() {
+					scanners = append(scanners, s)
+				}
 			case Many:
-				scanners = append(scanners, c.Scanner())
+				if s := c.Scanner(); !s.IsNil() {
+					scanners = append(scanners, s)
+				}
 			}
 		}
 	}
 
-	branchScanner, err := parser.MergeScanners(scanners...)
-	if err != nil {
-		panic(err)
+	if len(scanners) > 0 {
+		branchScanner, err := parser.MergeScanners(scanners...)
+		if err != nil {
+			panic(err)
+		}
+		return branchScanner
 	}
 
-	return branchScanner
+	return parser.Scanner{}
 }

--- a/ast/node_string.go
+++ b/ast/node_string.go
@@ -115,18 +115,17 @@ func (c One) Scanner() parser.Scanner {
 }
 
 func (c Many) Scanner() parser.Scanner {
-	childrenScanners := make([]parser.Scanner, len(c))
-	for i, n := range c {
-		childrenScanners[i] = n.Scanner()
+	childrenScanners := make([]parser.Scanner, 0, len(c))
+	for _, n := range c {
+		childrenScanners = append(childrenScanners, n.Scanner())
 	}
 
-	manyScanner := &parser.Scanner{}
-	err := manyScanner.Merge(childrenScanners)
+	manyScanner, err := parser.MergeScanners(childrenScanners...)
 	if err != nil {
 		panic(err)
 	}
 
-	return *manyScanner
+	return manyScanner
 }
 
 func (c Extra) Scanner() parser.Scanner {
@@ -154,11 +153,10 @@ func (n Branch) Scanner() parser.Scanner {
 		}
 	}
 
-	branchScanner := &parser.Scanner{}
-	err := branchScanner.Merge(scanners)
+	branchScanner, err := parser.MergeScanners(scanners...)
 	if err != nil {
 		panic(err)
 	}
 
-	return *branchScanner
+	return branchScanner
 }

--- a/ast/node_test.go
+++ b/ast/node_test.go
@@ -1,0 +1,64 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/arr-ai/wbnf/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBranchScanner(t *testing.T) {
+	str := "one\ntwo\nthree\nfour"
+
+	assertBranchScanner(t, parser.NewScannerAt(str, 0, 4), Branch{
+		"foo": One{
+			Node: Leaf(*parser.NewScannerAt(str, 0, 4)),
+		},
+	})
+	assertBranchScanner(t, parser.NewScannerAt(str, 0, 6), Branch{
+		"foo": One{
+			Node: Leaf(*parser.NewScannerAt(str, 0, 4)),
+		},
+		"bar": One{
+			Node: Leaf(*parser.NewScannerAt(str, 5, 1)),
+		},
+	})
+	assertBranchScanner(t, parser.NewScannerAt(str, 0, 11), Branch{
+		"foo": One{
+			Node: Leaf(*parser.NewScannerAt(str, 0, 4)),
+		},
+		"bar": One{
+			Node: Leaf(*parser.NewScannerAt(str, 10, 1)),
+		},
+	})
+	assertBranchScanner(t, parser.NewScannerAt(str, 0, 17), Branch{
+		"foo": Many{
+			Leaf(*parser.NewScannerAt(str, 0, 4)),
+			Leaf(*parser.NewScannerAt(str, 7, 10)),
+		},
+	})
+	assertBranchScanner(t, parser.NewScannerAt(str, 0, 17), Branch{
+		"foo": Many{
+			Leaf(*parser.NewScannerAt(str, 0, 4)),
+			Leaf(*parser.NewScannerAt(str, 7, 10)),
+		},
+		"bar": Many{
+			Leaf(*parser.NewScannerAt(str, 0, 4)),
+			Leaf(*parser.NewScannerAt(str, 7, 1)),
+		},
+	})
+	assertBranchScanner(t, parser.NewScannerAt(str, 0, 17), Branch{
+		"foo": Many{
+			Leaf(*parser.NewScannerAt(str, 0, 4)),
+			Leaf(*parser.NewScannerAt(str, 7, 10)),
+		},
+		"bar": One{
+			Node: Leaf(*parser.NewScannerAt(str, 5, 1)),
+		},
+	})
+
+}
+
+func assertBranchScanner(t *testing.T, s *parser.Scanner, b Branch) {
+	assert.Equal(t, *s, b.Scanner())
+}

--- a/ast/node_test.go
+++ b/ast/node_test.go
@@ -57,6 +57,20 @@ func TestBranchScanner(t *testing.T) {
 		},
 	})
 
+	assertBranchScanner(t, &parser.Scanner{}, Branch{})
+	assertBranchScanner(t, &parser.Scanner{}, Branch{
+		"foo": Many{},
+	})
+	assertBranchScanner(t, &parser.Scanner{}, Branch{
+		"foo": Many{},
+		"bar": Many{},
+	})
+	assertBranchScanner(t, parser.NewScannerAt(str, 5, 1), Branch{
+		"foo": Many{},
+		"bar": One{
+			Node: Leaf(*parser.NewScannerAt(str, 5, 1)),
+		},
+	})
 }
 
 func assertBranchScanner(t *testing.T, s *parser.Scanner, b Branch) {

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -65,7 +65,7 @@ func (s Scanner) Format(state fmt.State, c rune) {
 
 var (
 	NoLimit      = -1
-	DefaultLimit = 3
+	DefaultLimit = 1
 )
 
 func (s Scanner) Context(limitLines int) string {
@@ -85,7 +85,7 @@ func (s Scanner) Context(limitLines int) string {
 		}
 	}
 
-	return fmt.Sprintf("\n%s:%d:%d:\n\n%s\033[1;31m%s\033[0m%s",
+	return fmt.Sprintf("\n\033[1;37m%s:%d:%d:\033[0m\n%s\033[1;31m%s\033[0m%s",
 		s.Filename(),
 		lineno,
 		colno,

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -116,6 +117,33 @@ func (s Scanner) Slice(a, b int) *Scanner {
 
 func (s Scanner) Skip(i int) *Scanner {
 	return &Scanner{s.src, s.sliceStart + i, s.sliceLength - i}
+}
+
+func (s *Scanner) Merge(items []Scanner) error {
+	if len(items) < 2 {
+		return errors.New("merge needs at least two scanners")
+	}
+
+	l, r := items[0].sliceStart, items[0].sliceStart+items[0].sliceLength
+	src := items[0].src
+	fmt.Println(src)
+	for _, v := range items {
+		if v.src != src {
+			return errors.New("scanners' sources are not the same")
+		}
+		if v.sliceStart < l {
+			l = v.sliceStart
+		}
+		if v.sliceStart+v.sliceLength > r {
+			r = v.sliceStart + v.sliceLength
+		}
+	}
+
+	s.src = src
+	s.sliceStart = l
+	s.sliceLength = r - l
+
+	return nil
 }
 
 // Eat returns a scanner containing the next i bytes and advances s past them.

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -56,6 +56,10 @@ func (s Scanner) String() string {
 	return s.slice()
 }
 
+func (s Scanner) IsNil() bool {
+	return s.src == nil
+}
+
 func (s Scanner) Format(state fmt.State, c rune) {
 	if c == 'q' {
 		_, _ = fmt.Fprintf(state, "%q", s.slice())
@@ -123,7 +127,6 @@ func MergeScanners(items ...Scanner) (Scanner, error) {
 	if len(items) == 0 {
 		return Scanner{}, errors.New("needs at least one scanner")
 	}
-
 	if len(items) == 1 {
 		return items[0], nil
 	}
@@ -131,9 +134,9 @@ func MergeScanners(items ...Scanner) (Scanner, error) {
 	l, r := items[0].sliceStart, items[0].sliceStart+items[0].sliceLength
 	src := items[0].src
 
-	for _, v := range items {
+	for _, v := range items[1:] {
 		if v.src != src {
-			return Scanner{}, errors.New("scanners' sources are not the same")
+			return Scanner{}, fmt.Errorf("scanners' sources are not the same: %s vs %s", src, v.src)
 		}
 		if v.sliceStart < l {
 			l = v.sliceStart

--- a/parser/scanner.go
+++ b/parser/scanner.go
@@ -119,17 +119,21 @@ func (s Scanner) Skip(i int) *Scanner {
 	return &Scanner{s.src, s.sliceStart + i, s.sliceLength - i}
 }
 
-func (s *Scanner) Merge(items []Scanner) error {
-	if len(items) < 2 {
-		return errors.New("merge needs at least two scanners")
+func MergeScanners(items ...Scanner) (Scanner, error) {
+	if len(items) == 0 {
+		return Scanner{}, errors.New("needs at least one scanner")
+	}
+
+	if len(items) == 1 {
+		return items[0], nil
 	}
 
 	l, r := items[0].sliceStart, items[0].sliceStart+items[0].sliceLength
 	src := items[0].src
-	fmt.Println(src)
+
 	for _, v := range items {
 		if v.src != src {
-			return errors.New("scanners' sources are not the same")
+			return Scanner{}, errors.New("scanners' sources are not the same")
 		}
 		if v.sliceStart < l {
 			l = v.sliceStart
@@ -139,11 +143,11 @@ func (s *Scanner) Merge(items []Scanner) error {
 		}
 	}
 
-	s.src = src
-	s.sliceStart = l
-	s.sliceLength = r - l
-
-	return nil
+	return Scanner{
+		src:         src,
+		sliceStart:  l,
+		sliceLength: r - l,
+	}, nil
 }
 
 // Eat returns a scanner containing the next i bytes and advances s past them.

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -50,7 +50,7 @@ func TestScannerMerge(t *testing.T) {
 	assertMergedScanner(t, src, 0, 6, []Scanner{*NewScannerAt(str, 0, 1), *NewScannerAt(str, 0, 4), *NewScannerAt(str, 0, 6)})
 
 	assertMergedScannerErr(t, errors.New("needs at least one scanner"), []Scanner{})
-	assertMergedScannerErr(t, errors.New("scanners' sources are not the same"), []Scanner{*NewScanner(str), *NewScanner("another src")})
+	assertMergedScannerErr(t, errors.New("scanners' sources are not the same: {one\ntwo\nthree\nfour } vs {another src }"), []Scanner{*NewScanner(str), *NewScanner("another src")})
 }
 
 func assertMergedScanner(t *testing.T, src source, offset, length int, items []Scanner) {

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,4 +36,34 @@ func assertLineColumn(t *testing.T, scanner *Scanner, line, column int) {
 	l, c := scanner.Position()
 	assert.Equal(t, line, l)
 	assert.Equal(t, column, c)
+}
+
+func TestScannerMerge(t *testing.T) {
+	str := "one\ntwo\nthree\nfour"
+	src := stringSource{origin: str}
+
+	assertMergedScanner(t, src, 0, len(str), []Scanner{*NewScanner(str), *NewScanner(str)})
+	assertMergedScanner(t, src, 0, len(str), []Scanner{*NewScanner(str), *NewScannerAt(str, 0, 1)})
+	assertMergedScanner(t, src, 0, 11, []Scanner{*NewScannerAt(str, 0, 1), *NewScannerAt(str, 5, 6)})
+	assertMergedScanner(t, src, 0, 11, []Scanner{*NewScannerAt(str, 0, 1), *NewScannerAt(str, 3, 1), *NewScannerAt(str, 5, 6)})
+	assertMergedScanner(t, src, 0, 6, []Scanner{*NewScannerAt(str, 0, 1), *NewScannerAt(str, 0, 4), *NewScannerAt(str, 0, 6)})
+
+	assertMergedScannerErr(t, errors.New("merge needs at least two scanners"), []Scanner{})
+	assertMergedScannerErr(t, errors.New("merge needs at least two scanners"), []Scanner{*NewScanner(str)})
+	assertMergedScannerErr(t, errors.New("scanners' sources are not the same"), []Scanner{*NewScanner(str), *NewScanner("another src")})
+}
+
+func assertMergedScanner(t *testing.T, src source, offset, length int, items []Scanner) {
+	s := &Scanner{}
+	err := s.Merge(items)
+	assert.NoError(t, err)
+	assert.Equal(t, src, s.src)
+	assert.Equal(t, offset, s.sliceStart)
+	assert.Equal(t, length, s.sliceLength)
+}
+
+func assertMergedScannerErr(t *testing.T, err error, items []Scanner) {
+	s := &Scanner{}
+	e := s.Merge(items)
+	assert.Equal(t, err, e)
 }

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -42,20 +42,19 @@ func TestScannerMerge(t *testing.T) {
 	str := "one\ntwo\nthree\nfour"
 	src := stringSource{origin: str}
 
+	assertMergedScanner(t, src, 0, 5, []Scanner{*NewScannerAt(str, 0, 5)})
 	assertMergedScanner(t, src, 0, len(str), []Scanner{*NewScanner(str), *NewScanner(str)})
 	assertMergedScanner(t, src, 0, len(str), []Scanner{*NewScanner(str), *NewScannerAt(str, 0, 1)})
 	assertMergedScanner(t, src, 0, 11, []Scanner{*NewScannerAt(str, 0, 1), *NewScannerAt(str, 5, 6)})
 	assertMergedScanner(t, src, 0, 11, []Scanner{*NewScannerAt(str, 0, 1), *NewScannerAt(str, 3, 1), *NewScannerAt(str, 5, 6)})
 	assertMergedScanner(t, src, 0, 6, []Scanner{*NewScannerAt(str, 0, 1), *NewScannerAt(str, 0, 4), *NewScannerAt(str, 0, 6)})
 
-	assertMergedScannerErr(t, errors.New("merge needs at least two scanners"), []Scanner{})
-	assertMergedScannerErr(t, errors.New("merge needs at least two scanners"), []Scanner{*NewScanner(str)})
+	assertMergedScannerErr(t, errors.New("needs at least one scanner"), []Scanner{})
 	assertMergedScannerErr(t, errors.New("scanners' sources are not the same"), []Scanner{*NewScanner(str), *NewScanner("another src")})
 }
 
 func assertMergedScanner(t *testing.T, src source, offset, length int, items []Scanner) {
-	s := &Scanner{}
-	err := s.Merge(items)
+	s, err := MergeScanners(items...)
 	assert.NoError(t, err)
 	assert.Equal(t, src, s.src)
 	assert.Equal(t, offset, s.sliceStart)
@@ -63,7 +62,6 @@ func assertMergedScanner(t *testing.T, src source, offset, length int, items []S
 }
 
 func assertMergedScannerErr(t *testing.T, err error, items []Scanner) {
-	s := &Scanner{}
-	e := s.Merge(items)
+	_, e := MergeScanners(items...)
 	assert.Equal(t, err, e)
 }


### PR DESCRIPTION
Changes:
- add Merge function to merge multiple same-src Scanners
- implement Scanner function for `Many` and `Branch`
- bold context filename text and show oneline context by default
