### PR TITLE
Disambiguate 'unexpected term type' panic messages

### DIFF
--- a/ast/counter.go
+++ b/ast/counter.go
@@ -126,6 +126,6 @@ func (ctrs counters) termCountChildren(term parser.Term, parent counter) {
 	case parser.ExtRef:
 		ctrs.count(string(t), parent)
 	default:
-		panic(fmt.Errorf("unexpected term type: %v %[1]T", t))
+		panic(fmt.Errorf("unexpected term type for counter: %v %[1]T", t))
 	}
 }

--- a/ast/counter.go
+++ b/ast/counter.go
@@ -126,6 +126,6 @@ func (ctrs counters) termCountChildren(term parser.Term, parent counter) {
 	case parser.ExtRef:
 		ctrs.count(string(t), parent)
 	default:
-		panic(fmt.Errorf("unexpected term type for counter: %v %[1]T", t))
+		panic(fmt.Errorf("counters.termCountChildren: unexpected term type: %v %[1]T", t))
 	}
 }

--- a/ast/from_parsernode.go
+++ b/ast/from_parsernode.go
@@ -209,6 +209,6 @@ func (b Branch) fromParserNode(g parser.Grammar, term parser.Term, ctrs counters
 			}
 		}
 	default:
-		panic(fmt.Errorf("unexpected term type in parser node: %v %[1]T", t))
+		panic(fmt.Errorf("branch.fromParserNode: unexpected term type: %v %[1]T", t))
 	}
 }

--- a/ast/from_parsernode.go
+++ b/ast/from_parsernode.go
@@ -209,6 +209,6 @@ func (b Branch) fromParserNode(g parser.Grammar, term parser.Term, ctrs counters
 			}
 		}
 	default:
-		panic(fmt.Errorf("unexpected term type: %v %[1]T", t))
+		panic(fmt.Errorf("unexpected term type in parser node: %v %[1]T", t))
 	}
 }

--- a/ast/to_parsernode.go
+++ b/ast/to_parsernode.go
@@ -180,6 +180,6 @@ func (b Branch) toParserNode(g parser.Grammar, term parser.Term, ctrs counters) 
 	case parser.CutPoint:
 		return b.toParserNode(g, t.Term, ctrs)
 	default:
-		panic(fmt.Errorf("unexpected term type: %v %[1]T", t))
+		panic(fmt.Errorf("unexpected term type to parser node: %v %[1]T", t))
 	}
 }

--- a/ast/to_parsernode.go
+++ b/ast/to_parsernode.go
@@ -180,6 +180,6 @@ func (b Branch) toParserNode(g parser.Grammar, term parser.Term, ctrs counters) 
 	case parser.CutPoint:
 		return b.toParserNode(g, t.Term, ctrs)
 	default:
-		panic(fmt.Errorf("unexpected term type to parser node: %v %[1]T", t))
+		panic(fmt.Errorf("branch.toParserNode: unexpected term type: %v %[1]T", t))
 	}
 }

--- a/cmd/codegen/grammar.go
+++ b/cmd/codegen/grammar.go
@@ -155,7 +155,7 @@ func walkTerm(term parser.Term) GoNode {
 	case parser.ExtRef:
 		node = stringNode("parser.ExtRef(`%s`)", safeString(string(t)))
 	default:
-		panic(fmt.Errorf("unexpected term type: %v %[1]T", t))
+		panic(fmt.Errorf("unexpected term type in walk: %v %[1]T", t))
 	}
 
 	return node

--- a/cmd/codegen/grammar.go
+++ b/cmd/codegen/grammar.go
@@ -155,7 +155,7 @@ func walkTerm(term parser.Term) GoNode {
 	case parser.ExtRef:
 		node = stringNode("parser.ExtRef(`%s`)", safeString(string(t)))
 	default:
-		panic(fmt.Errorf("unexpected term type in walk: %v %[1]T", t))
+		panic(fmt.Errorf("walkTerm: unexpected term type: %v %[1]T", t))
 	}
 
 	return node

--- a/wbnf/cutpoints.go
+++ b/wbnf/cutpoints.go
@@ -105,7 +105,7 @@ func findUniqueStrings(g parser.Grammar) frozen.Set {
 			out = out.Merge(forTerm(t.Term), mergeFn)
 		case parser.RE, parser.Rule, parser.ExtRef: // do nothing
 		default:
-			panic(fmt.Errorf("unexpected term type: %v %[1]T", t))
+			panic(fmt.Errorf("unexpected term type for unique string: %v %[1]T", t))
 		}
 		return out
 	}
@@ -166,6 +166,6 @@ func fixTerm(term parser.Term, callback func(t parser.Term) parser.Term) parser.
 	case parser.S, parser.REF, parser.RE, parser.Rule, parser.ExtRef:
 		return callback(term)
 	default:
-		panic(fmt.Errorf("unexpected term type: %v %[1]T", t))
+		panic(fmt.Errorf("unexpected term type for fix: %v %[1]T", t))
 	}
 }

--- a/wbnf/cutpoints.go
+++ b/wbnf/cutpoints.go
@@ -105,7 +105,7 @@ func findUniqueStrings(g parser.Grammar) frozen.Set {
 			out = out.Merge(forTerm(t.Term), mergeFn)
 		case parser.RE, parser.Rule, parser.ExtRef: // do nothing
 		default:
-			panic(fmt.Errorf("unexpected term type for unique string: %v %[1]T", t))
+			panic(fmt.Errorf("findUniqueStrings: unexpected term type: %v %[1]T", t))
 		}
 		return out
 	}
@@ -166,6 +166,6 @@ func fixTerm(term parser.Term, callback func(t parser.Term) parser.Term) parser.
 	case parser.S, parser.REF, parser.RE, parser.Rule, parser.ExtRef:
 		return callback(term)
 	default:
-		panic(fmt.Errorf("unexpected term type for fix: %v %[1]T", t))
+		panic(fmt.Errorf("fixTerm: unexpected term type: %v %[1]T", t))
 	}
 }


### PR DESCRIPTION
Multiple code paths can produce the same error message, adding unnecessary overhead to debugging.