### PR TITLE
Bump logrus from v1.9.0 to v1.9.3 to close CVE-2025-65637

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/arr-ai/frozen v1.4.0
 	github.com/iancoleman/strcase v0.2.0
-	github.com/sirupsen/logrus v1.9.0
+	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.0
 	github.com/urfave/cli v1.22.10
 )

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=


### PR DESCRIPTION
Closes the high-severity Dependabot alert at
https://github.com/arr-ai/wbnf/security/dependabot/2.

The advisory describes a denial-of-service in
github.com/sirupsen/logrus when Entry.Writer() is used to log a
single-line payload larger than 64KB without newlines: the internal
bufio.Scanner fails with "token too long", the writer pipe closes,
and Writer() becomes permanently unusable.

Reachability in this repo: none. No source file calls .Writer() on
any logrus object (grep for `\.Writer\(\)` returns zero matches), so
the DoS was never exploitable from wbnf's own code. The bump closes
the theoretical surface if any future change introduces a .Writer()
call, and clears the GitHub security alert.

Resolves 🎯T2.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
