### PR TITLE
Fix setup-go/checkout order and gitignore .claude/

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,13 +9,13 @@ jobs:
     name: Lint
     runs-on: ${{ vars.RUNNER_UBUNTU && fromJSON(vars.RUNNER_UBUNTU) || 'ubuntu-latest' }}
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v6
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version: 1.19
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v6
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v9
@@ -24,13 +24,13 @@ jobs:
     name: Build
     runs-on: ${{ vars.RUNNER_UBUNTU && fromJSON(vars.RUNNER_UBUNTU) || 'ubuntu-latest' }}
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v6
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version: 1.19
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v6
 
     - name: Build
       run: make build
@@ -39,13 +39,13 @@ jobs:
     name: Test
     runs-on: ${{ vars.RUNNER_UBUNTU && fromJSON(vars.RUNNER_UBUNTU) || 'ubuntu-latest' }}
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v6
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version: 1.19
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v6
 
     - name: Run tests
       run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ dist/
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .idea/
+
+# Claude Code local agent state (per-project conversation history, etc.)
+.claude/


### PR DESCRIPTION
Two small follow-ups from PR #96:

- go.yml: reorder steps so checkout runs before setup-go in all three
  jobs. actions/setup-go@v6 tries to restore the Go module cache by
  reading go.mod, but the previous order ran it before checkout, so
  go.mod wasn't on disk yet. The cache-restore emitted a non-fatal
  annotation on every run ("Dependencies file is not found"). With
  the correct order, the cache now restores successfully.

- .gitignore: add .claude/ for Claude Code's per-project agent state.
  The directory has been sitting untracked in every working tree this
  session; adding it to .gitignore stops it showing up in git status.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
